### PR TITLE
Add INY instruction

### DIFF
--- a/crates/rmachine-core/src/machine.rs
+++ b/crates/rmachine-core/src/machine.rs
@@ -6,21 +6,6 @@ use std::fmt::Write;
 use anyhow::Result;
 use anyhow::anyhow;
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
-pub struct Register(pub &'static str);
-
-impl From<&'static str> for Register {
-    fn from(value: &'static str) -> Self {
-        Self(value)
-    }
-}
-
-impl Display for Register {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
 #[derive(Debug, Clone)]
 pub enum Operation {
     NoOp,
@@ -37,18 +22,18 @@ impl Operation {
 
 #[derive(Debug, Clone)]
 pub struct Instruction {
-    pub mnemonic: String,
+    pub mnemonic: &'static str,
     pub opcode: u8,
     pub operation: Operation,
-    pub register: Register,
+    pub register: &'static str,
 }
 
 #[derive(Debug, Default)]
 pub struct Machine {
     memory: Vec<u8>,
     pc: u16,
-    pub registers: HashMap<Register, u8>,
-    instructions: HashMap<u8, Instruction>,
+    pub registers: HashMap<&'static str, u8>,
+    instructions: HashMap<u8, &'static Instruction>,
 }
 
 #[derive(Default)]
@@ -71,15 +56,15 @@ impl MachineBuilder {
     }
 
     #[must_use]
-    pub fn with_registers(mut self, registers: Vec<&'static str>) -> Self {
+    pub fn with_registers(mut self, registers: &[&'static str]) -> Self {
         for register in registers {
-            self.machine.registers.insert(Register(register), 0);
+            self.machine.registers.insert(register, 0);
         }
         self
     }
 
     #[must_use]
-    pub fn with_instructions(mut self, instructions: Vec<Instruction>) -> Self {
+    pub fn with_instructions(mut self, instructions: &'static [Instruction]) -> Self {
         for instruction in instructions {
             self.machine
                 .instructions
@@ -129,7 +114,7 @@ impl Machine {
             } => {
                 let imm = self.next()?;
                 self.registers
-                    .entry(register.clone())
+                    .entry(register)
                     .and_modify(|value| *value = imm);
             }
             Instruction {
@@ -138,7 +123,7 @@ impl Machine {
                 ..
             } => {
                 self.registers
-                    .entry(register.clone())
+                    .entry(register)
                     .and_modify(|value| *value += 1);
             }
             instruction => unimplemented!("unknown instruction: {instruction:#?}"),
@@ -184,7 +169,7 @@ impl Machine {
     pub fn disassemble_next(&self) -> Option<String> {
         let opcode = self.memory.get(self.pc as usize)?;
         let instruction = self.instructions.get(opcode)?;
-        let mut disassembly = instruction.mnemonic.clone();
+        let mut disassembly = String::from(instruction.mnemonic);
         if instruction.operation.takes_arg() {
             let value = self.memory.get(self.pc as usize + 1)?;
             write!(disassembly, " {value:04x}").ok()?;
@@ -264,27 +249,28 @@ impl Display for Machine {
 mod tests {
     use super::*;
 
-    fn new_tiny_machine() -> Machine {
-        let registers = vec!["a", "x", "y"];
-        let instructions = vec![
-            Instruction {
-                mnemonic: "nop".to_string(),
-                opcode: 0x00,
-                operation: Operation::NoOp,
-                register: Register::default(),
-            },
-            Instruction {
-                mnemonic: "lda".to_string(),
-                opcode: 0x01,
-                operation: Operation::LoadImm,
-                register: Register("a"),
-            },
-        ];
+    const REGISTERS: &[&str] = &["A", "X", "Y"];
+    
+    const INSTRUCTIONS: &[Instruction] = &[
+        Instruction {
+            mnemonic: "NOP",
+            opcode: 0x00,
+            operation: Operation::NoOp,
+            register: "",
+        },
+        Instruction {
+            mnemonic: "LDA",
+            opcode: 0x01,
+            operation: Operation::LoadImm,
+            register: "A",
+        },
+    ];
 
+    fn new_tiny_machine() -> Machine {
         MachineBuilder::default()
             .with_memory(1024)
-            .with_registers(registers)
-            .with_instructions(instructions)
+            .with_registers(REGISTERS)
+            .with_instructions(INSTRUCTIONS)
             .build()
     }
 

--- a/crates/rmachine-core/src/machine.rs
+++ b/crates/rmachine-core/src/machine.rs
@@ -33,6 +33,7 @@ pub struct Machine {
     memory: Vec<u8>,
     pc: u16,
     pub registers: HashMap<&'static str, u8>,
+    register_list: &'static [&'static str],
     instructions: HashMap<u8, &'static Instruction>,
 }
 
@@ -56,7 +57,8 @@ impl MachineBuilder {
     }
 
     #[must_use]
-    pub fn with_registers(mut self, registers: &[&'static str]) -> Self {
+    pub fn with_registers(mut self, registers: &'static [&'static str]) -> Self {
+        self.machine.register_list = registers;
         for register in registers {
             self.machine.registers.insert(register, 0);
         }
@@ -98,7 +100,7 @@ impl Machine {
         let instruction = self
             .instructions
             .get(&opcode)
-            .cloned()
+            .copied()
             .ok_or_else(|| anyhow!("opcode not found: {opcode}"))?;
 
         #[expect(unreachable_patterns, reason = "we're not done yet")]
@@ -113,23 +115,45 @@ impl Machine {
                 ..
             } => {
                 let imm = self.next()?;
-                self.registers
-                    .entry(register)
-                    .and_modify(|value| *value = imm);
+                let reg = self.reg_mut(register);
+                *reg += imm;
             }
             Instruction {
                 operation: Operation::IncrementRegister,
                 register,
                 ..
             } => {
-                self.registers
-                    .entry(register)
-                    .and_modify(|value| *value += 1);
+                let reg = self.reg_mut(register);
+                *reg += 1;
             }
             instruction => unimplemented!("unknown instruction: {instruction:#?}"),
         }
-
         Ok(())
+    }
+
+    /// Returns a copy of the named register contents.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the named register does not exist.
+    pub fn reg(&mut self, reg_name: &str) -> u8 {
+        self.registers
+            .get(reg_name)
+            .copied()
+            .ok_or_else(|| format!("undefined register '{reg_name}'"))
+            .unwrap()
+    }
+
+    /// Returns a mutable reference to the named register contents.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the named register does not exist.
+    pub fn reg_mut(&mut self, reg_name: &str) -> &mut u8 {
+        self.registers
+            .get_mut(reg_name)
+            .ok_or_else(|| format!("undefined register '{reg_name}'"))
+            .unwrap()
     }
 
     /// Fetch the next byte from memory.
@@ -180,19 +204,23 @@ impl Machine {
 
 impl Display for Machine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "pc   ")?;
-        for reg in self.registers.keys() {
-            write!(f, "{reg:4} ")?;
+        write!(f, "PC   ")?;
+        for reg in self.register_list {
+            write!(f, "{reg:} ")?;
         }
-        writeln!(f)?;
-        write!(f, "{:04x} ", self.pc)?;
-        for value in self.registers.values() {
-            write!(f, "{value:04x} ")?;
+        writeln!(f, "INST")?;
+        write!(f, "{:04X} ", self.pc)?;
+        for reg in self.register_list {
+            write!(
+                f,
+                "{:02X} ",
+                self.registers
+                    .get(reg)
+                    .expect("reg should have a hashmap entry")
+            )?;
         }
-        if let Some(instruction) = self.disassemble_next() {
-            write!(f, ": {instruction}")?;
-        }
-        writeln!(f)?;
+        let instruction = self.disassemble_next().unwrap_or("???".into());
+        writeln!(f, "{instruction}")?;
         Ok(())
     }
 }
@@ -250,7 +278,7 @@ mod tests {
     use super::*;
 
     const REGISTERS: &[&str] = &["A", "X", "Y"];
-    
+
     const INSTRUCTIONS: &[Instruction] = &[
         Instruction {
             mnemonic: "NOP",

--- a/crates/rmachine-core/src/prelude.rs
+++ b/crates/rmachine-core/src/prelude.rs
@@ -1,1 +1,1 @@
-pub use crate::machine::{Instruction, Machine, MachineBuilder, Operation, Register};
+pub use crate::machine::{Instruction, Machine, MachineBuilder, Operation};

--- a/crates/rmachine-mos6502/src/lib.rs
+++ b/crates/rmachine-mos6502/src/lib.rs
@@ -2,17 +2,17 @@ use std::ops::{Deref, DerefMut};
 
 use rmachine_core::prelude::*;
 
-const REGISTERS: &[&str] = &["PC", "AC", "X", "Y", "SR", "SP"];
+const REGISTERS: &[&str] = &["PC", "SR", "AC", "XR", "YR", "SP"];
 
 const INSTRUCTIONS: &[Instruction] = &[
     Instruction {
-        mnemonic: "lda",
+        mnemonic: "LDA",
         opcode: 0xA9,
         operation: Operation::LoadImm,
         register: "AC",
     },
     Instruction {
-        mnemonic: "inx",
+        mnemonic: "LDA",
         opcode: 0xE8,
         operation: Operation::IncrementRegister,
         register: "X",

--- a/crates/rmachine-mos6502/src/lib.rs
+++ b/crates/rmachine-mos6502/src/lib.rs
@@ -2,7 +2,7 @@ use std::ops::{Deref, DerefMut};
 
 use rmachine_core::prelude::*;
 
-const REGISTERS: &[&str] = &["PC", "SR", "AC", "XR", "YR", "SP"];
+const REGISTERS: &[&str] = &["SR", "AC", "XR", "YR", "SP"];
 
 const INSTRUCTIONS: &[Instruction] = &[
     Instruction {
@@ -12,10 +12,16 @@ const INSTRUCTIONS: &[Instruction] = &[
         register: "AC",
     },
     Instruction {
-        mnemonic: "LDA",
+        mnemonic: "INY",
+        opcode: 0xC8,
+        operation: Operation::IncrementRegister,
+        register: "YR",
+    },
+    Instruction {
+        mnemonic: "INX",
         opcode: 0xE8,
         operation: Operation::IncrementRegister,
-        register: "X",
+        register: "XR",
     },
 ];
 
@@ -59,28 +65,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn machine_6502_increments_register_x() {
+    fn machine_6502_increments_registers_x_and_y() {
         let mut machine = MOS6502::new();
-
-        machine.load(0, &[0xE8]).unwrap();
-
+        machine.load(0, &[0xE8, 0xC8]).unwrap();
         machine.step().unwrap();
-
-        let want = 1;
-        let got = machine.registers.get("X").copied().unwrap();
-        assert_eq!(want, got);
+        assert_eq!(machine.reg("XR"), 1, "wrong X value");
+        machine.step().unwrap();
+        assert_eq!(machine.reg("YR"), 1, "wrong Y value");
     }
 
     #[test]
     fn machine_6502_loads_immediate_into_register_a() {
         let mut machine = MOS6502::new();
-
         machine.load(0, &[0xA9, 0xFF]).unwrap();
-
         machine.step().unwrap();
-
-        let want = 0xFF;
-        let got = machine.registers.get("AC").copied().unwrap();
-        assert_eq!(want, got);
+        assert_eq!(machine.reg("AC"), 0xFF, "wrong AC value");
     }
 }

--- a/crates/rmachine-mos6502/src/lib.rs
+++ b/crates/rmachine-mos6502/src/lib.rs
@@ -2,6 +2,23 @@ use std::ops::{Deref, DerefMut};
 
 use rmachine_core::prelude::*;
 
+const REGISTERS: &[&str] = &["PC", "AC", "X", "Y", "SR", "SP"];
+
+const INSTRUCTIONS: &[Instruction] = &[
+    Instruction {
+        mnemonic: "lda",
+        opcode: 0xA9,
+        operation: Operation::LoadImm,
+        register: "AC",
+    },
+    Instruction {
+        mnemonic: "inx",
+        opcode: 0xE8,
+        operation: Operation::IncrementRegister,
+        register: "X",
+    },
+];
+
 #[derive(Debug)]
 pub struct MOS6502(Machine);
 
@@ -28,25 +45,10 @@ impl DerefMut for MOS6502 {
 
 impl Default for MOS6502 {
     fn default() -> Self {
-        let registers = vec!["a", "x", "y", "f"];
-        let instructions = vec![
-            Instruction {
-                mnemonic: "lda".to_string(),
-                opcode: 0xA9,
-                operation: Operation::LoadImm,
-                register: Register("a"),
-            },
-            Instruction {
-                mnemonic: "inx".to_string(),
-                opcode: 0xE8,
-                operation: Operation::IncrementRegister,
-                register: Register("x"),
-            },
-        ];
         let machine = MachineBuilder::default()
             .with_memory(1024)
-            .with_registers(registers)
-            .with_instructions(instructions)
+            .with_registers(REGISTERS)
+            .with_instructions(INSTRUCTIONS)
             .build();
         Self(machine)
     }
@@ -65,7 +67,7 @@ mod tests {
         machine.step().unwrap();
 
         let want = 1;
-        let got = machine.registers.get(&"x".into()).copied().unwrap();
+        let got = machine.registers.get("X").copied().unwrap();
         assert_eq!(want, got);
     }
 
@@ -78,7 +80,7 @@ mod tests {
         machine.step().unwrap();
 
         let want = 0xFF;
-        let got = machine.registers.get(&"a".into()).copied().unwrap();
+        let got = machine.registers.get("AC").copied().unwrap();
         assert_eq!(want, got);
     }
 }


### PR DESCRIPTION
Mostly just cleanup and convenience work around register/ISA definition and access, but—to move the needle a tiny amount—also adding an `INY` instruction.

The 6502 register names and monitor layout are taken from https://www.masswerk.at/6502/6502_instruction_set.html