### PR TITLE
Add simple cycle timing

### DIFF
--- a/crates/rmachine-core/src/machine.rs
+++ b/crates/rmachine-core/src/machine.rs
@@ -2,6 +2,8 @@
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::fmt::Write;
+use std::thread::sleep;
+use std::time::Duration;
 
 use anyhow::Result;
 use anyhow::anyhow;
@@ -19,71 +21,66 @@ pub struct Instruction {
     pub opcode: u8,
     pub operands: Operands,
     pub execute: fn(&mut Machine),
-    pub cycles: usize,
+    pub cycles: u8,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Machine {
     memory: Vec<u8>,
     pc: u16,
     pub registers: HashMap<&'static str, u8>,
     register_list: &'static [&'static str],
     instructions: HashMap<u8, &'static Instruction>,
-    cycles: usize,
+    cycles: u32,
+    cycle_time_ns: u32,
+    timer_ns: usize,
 }
 
-#[derive(Default)]
+#[derive(Debug)]
 pub struct MachineBuilder {
-    machine: Machine,
+    pub memory_size: usize,
+    pub registers: &'static [&'static str],
+    pub instructions: &'static [Instruction],
+    pub frequency_mhz: f32,
 }
 
 impl MachineBuilder {
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            machine: Machine::default(),
-        }
-    }
-
-    #[must_use]
-    pub fn with_memory(mut self, memory_size: usize) -> Self {
-        self.machine.memory.resize(memory_size, 0);
-        self
-    }
-
-    #[must_use]
-    pub fn with_registers(mut self, registers: &'static [&'static str]) -> Self {
-        self.machine.register_list = registers;
-        for register in registers {
-            self.machine.registers.insert(register, 0);
-        }
-        self
-    }
-
-    /// Add instructions to builder.
+    /// Returns a `Machine` configured according to the builder specification.
     ///
     /// # Panics
     ///
     /// Will panic if an instruction with the same opcode already exists.
     #[must_use]
-    pub fn with_instructions(mut self, instructions: &'static [Instruction]) -> Self {
-        for instruction in instructions {
-            let present = self
-                .machine
-                .instructions
-                .insert(instruction.opcode, instruction);
-            assert!(
-                present.is_none(),
-                "duplicate opcode: 0x{:0X}",
-                instruction.opcode
-            );
-        }
-        self
-    }
-
-    #[must_use]
     pub fn build(self) -> Machine {
-        self.machine
+        assert!(self.frequency_mhz.is_sign_positive());
+        Machine {
+            memory: vec![0; self.memory_size],
+            registers: {
+                let mut registers: HashMap<&'static str, u8> = HashMap::new();
+                for register in self.registers {
+                    registers.insert(register, 0);
+                }
+                registers
+            },
+            register_list: self.registers,
+            instructions: {
+                let mut instructions = HashMap::new();
+                for instruction in self.instructions {
+                    let present = instructions.insert(instruction.opcode, instruction);
+                    assert!(
+                        present.is_none(),
+                        "duplicate opcode: {:#0X}",
+                        instruction.opcode
+                    );
+                }
+                instructions
+            },
+            #[expect(clippy::cast_sign_loss, reason = "previously asserted positive")]
+            cycle_time_ns: (1000.0 / self.frequency_mhz) as u32,
+            pc: 0,
+            cycles: 0,
+            timer_ns: 0,
+        }
     }
 }
 
@@ -178,8 +175,40 @@ impl Machine {
         Ok(())
     }
 
-    pub fn wait_cycles(&mut self, cycles: usize) {
-        self.cycles = self.cycles.wrapping_add(cycles);
+    /// Sleeps long enough to slow the emulator down to roughly the machine's
+    /// rated clock frequency.
+    ///
+    /// Also updates the cycle counter and cycle timer, used to report the
+    /// actual speed achieved (by [`Self::speed_mhz`]).
+    pub fn wait_cycles(&mut self, cycles: u8) {
+        let cycles = u32::from(cycles);
+        let delay = cycles * self.cycle_time_ns;
+        sleep(Duration::from_nanos(u64::from(delay)));
+        let (new_cycles, overflow) = self.cycles.overflowing_add(cycles);
+        if overflow {
+            self.cycles = 0;
+            self.timer_ns = 0;
+        } else {
+            self.cycles = new_cycles;
+            self.timer_ns = self.timer_ns.saturating_add(delay as usize);
+        }
+    }
+
+    /// Reports the approximate speed achieved by the machine in MHz.
+    ///
+    /// This is based on the number of cycles executed since the last cycle
+    /// counter reset, divided by the internal timer value.
+    ///
+    /// Emulator overhead is not accounted for, and is assumed to be negligible
+    /// relative to the rated clock frequency.
+    #[must_use]
+    #[expect(clippy::cast_precision_loss, reason = "approximate speed is fine")]
+    pub fn speed_mhz(&self) -> f32 {
+        if self.cycles == 0 {
+            1000.0 / self.cycle_time_ns as f32
+        } else {
+            self.cycles as f32 / self.timer_ns as f32 * 1000.0
+        }
     }
 
     /// Gets opcode for instruction mnemonic.
@@ -221,7 +250,7 @@ impl Display for Machine {
         for reg in self.register_list {
             write!(f, "{reg:} ")?;
         }
-        writeln!(f, "INST")?;
+        writeln!(f, "INST       SPD")?;
         write!(f, "{:04X} ", self.pc)?;
         for reg in self.register_list {
             write!(
@@ -233,7 +262,7 @@ impl Display for Machine {
             )?;
         }
         let instruction = self.disassemble_next().unwrap_or("???".into());
-        writeln!(f, "{instruction}")?;
+        writeln!(f, "{instruction:10} {:.2}MHz", self.speed_mhz())?;
         Ok(())
     }
 }
@@ -242,34 +271,32 @@ impl Display for Machine {
 mod tests {
     use super::*;
 
-    const REGISTERS: &[&str] = &["A", "X", "Y"];
-
-    const INSTRUCTIONS: &[Instruction] = &[
-        Instruction {
-            mnemonic: "NOP",
-            opcode: 0x00,
-            operands: Operands::Zero,
-            execute: |_| (),
-            cycles: 2,
-        },
-        Instruction {
-            mnemonic: "LDA",
-            opcode: 0x01,
-            operands: Operands::One,
-            execute: |m| {
-                let value = m.fetch().unwrap();
-                m.reg_set("AC", value);
-            },
-            cycles: 2,
-        },
-    ];
-
     fn new_tiny_machine() -> Machine {
-        MachineBuilder::default()
-            .with_memory(1024)
-            .with_registers(REGISTERS)
-            .with_instructions(INSTRUCTIONS)
-            .build()
+        MachineBuilder {
+            memory_size: 1024,
+            registers: &["A", "X", "Y"],
+            instructions: &[
+                Instruction {
+                    mnemonic: "NOP",
+                    opcode: 0x00,
+                    operands: Operands::Zero,
+                    execute: |_| (),
+                    cycles: 2,
+                },
+                Instruction {
+                    mnemonic: "LDA",
+                    opcode: 0x01,
+                    operands: Operands::One,
+                    execute: |m| {
+                        let value = m.fetch().unwrap();
+                        m.reg_set("AC", value);
+                    },
+                    cycles: 2,
+                },
+            ],
+            frequency_mhz: 1.0,
+        }
+        .build()
     }
 
     #[test]

--- a/crates/rmachine-core/src/machine.rs
+++ b/crates/rmachine-core/src/machine.rs
@@ -19,6 +19,7 @@ pub struct Instruction {
     pub opcode: u8,
     pub operands: Operands,
     pub execute: fn(&mut Machine),
+    pub cycles: usize,
 }
 
 #[derive(Debug, Default)]
@@ -28,6 +29,7 @@ pub struct Machine {
     pub registers: HashMap<&'static str, u8>,
     register_list: &'static [&'static str],
     instructions: HashMap<u8, &'static Instruction>,
+    cycles: usize,
 }
 
 #[derive(Default)]
@@ -107,7 +109,7 @@ impl Machine {
             .ok_or_else(|| anyhow!("opcode not found: {opcode}"))?;
 
         (instruction.execute)(self);
-
+        self.wait_cycles(instruction.cycles);
         Ok(())
     }
 
@@ -174,6 +176,10 @@ impl Machine {
             .ok_or_else(|| anyhow!("memory out of bounds: {addr:#x}"))?;
         slice.copy_from_slice(program);
         Ok(())
+    }
+
+    pub fn wait_cycles(&mut self, cycles: usize) {
+        self.cycles = self.cycles.wrapping_add(cycles);
     }
 
     /// Gets opcode for instruction mnemonic.
@@ -244,6 +250,7 @@ mod tests {
             opcode: 0x00,
             operands: Operands::Zero,
             execute: |_| (),
+            cycles: 2,
         },
         Instruction {
             mnemonic: "LDA",
@@ -253,6 +260,7 @@ mod tests {
                 let value = m.fetch().unwrap();
                 m.reg_set("AC", value);
             },
+            cycles: 2,
         },
     ];
 
@@ -273,6 +281,23 @@ mod tests {
         machine.step().unwrap();
 
         assert_eq!(machine.pc, 1);
+    }
+
+    #[test]
+    fn cycles_are_counted() {
+        let mut machine = new_tiny_machine();
+        machine
+            .load(
+                0,
+                &[
+                    0x00, // 0x0000 NOP (2 cycles)
+                    0x00, // 0x0001 NOP (2 cycles)
+                ],
+            )
+            .unwrap();
+        machine.step().unwrap();
+        machine.step().unwrap();
+        assert_eq!(machine.cycles, 4);
     }
 
     // #[test]

--- a/crates/rmachine-mos6502/src/flags.rs
+++ b/crates/rmachine-mos6502/src/flags.rs
@@ -1,0 +1,2 @@
+pub const CARRY: u8 = 0b0000_0001;
+pub const DECIMAL: u8 = 0b0000_1000;

--- a/crates/rmachine-mos6502/src/instructions.rs
+++ b/crates/rmachine-mos6502/src/instructions.rs
@@ -1,0 +1,78 @@
+use rmachine_core::prelude::*;
+
+use crate::flags::{CARRY, DECIMAL};
+
+pub const INSTRUCTIONS: &[Instruction] = &[
+    Instruction {
+        mnemonic: "CLC",
+        opcode: 0x18,
+        operands: Operands::Zero,
+        execute: |m| {
+            let status = m.reg_mut("SR");
+            *status &= !CARRY;
+        },
+        cycles: 2,
+    },
+    Instruction {
+        mnemonic: "CLD",
+        opcode: 0xD8,
+        operands: Operands::Zero,
+        execute: |m| {
+            let status = m.reg_mut("SR");
+            *status &= !DECIMAL;
+        },
+        cycles: 2,
+    },
+    Instruction {
+        mnemonic: "ADC",
+        opcode: 0x69,
+        operands: Operands::One,
+        execute: |m| {
+            let carry = m.reg("SR") & CARRY;
+            let operand = m.fetch().unwrap();
+            let reg = m.reg_mut("AC");
+
+            let (result, overflow) = reg.overflowing_add(operand);
+            let (result, overflow2) = result.overflowing_add(carry);
+            *reg = result;
+
+            let status = m.reg_mut("SR");
+            if overflow || overflow2 {
+                *status |= CARRY;
+            } else {
+                *status &= !CARRY;
+            }
+        },
+        cycles: 2,
+    },
+    Instruction {
+        mnemonic: "LDA",
+        opcode: 0xA9,
+        operands: Operands::One,
+        execute: |m| {
+            let value = m.fetch().unwrap();
+            m.reg_set("AC", value);
+        },
+        cycles: 2,
+    },
+    Instruction {
+        mnemonic: "INY",
+        opcode: 0xC8,
+        operands: Operands::Zero,
+        execute: |m| {
+            let reg = m.reg_mut("YR");
+            *reg = reg.wrapping_add(1);
+        },
+        cycles: 2,
+    },
+    Instruction {
+        mnemonic: "INX",
+        opcode: 0xE8,
+        operands: Operands::Zero,
+        execute: |m| {
+            let reg = m.reg_mut("XR");
+            *reg = reg.wrapping_add(1);
+        },
+        cycles: 2,
+    },
+];

--- a/crates/rmachine-mos6502/src/lib.rs
+++ b/crates/rmachine-mos6502/src/lib.rs
@@ -16,6 +16,7 @@ const INSTRUCTIONS: &[Instruction] = &[
             let status = m.reg_mut("SR");
             *status &= !CARRY;
         },
+        cycles: 2,
     },
     Instruction {
         mnemonic: "CLD",
@@ -25,6 +26,7 @@ const INSTRUCTIONS: &[Instruction] = &[
             let status = m.reg_mut("SR");
             *status &= !DECIMAL;
         },
+        cycles: 2,
     },
     Instruction {
         mnemonic: "ADC",
@@ -46,6 +48,7 @@ const INSTRUCTIONS: &[Instruction] = &[
                 *status &= !CARRY;
             }
         },
+        cycles: 2,
     },
     Instruction {
         mnemonic: "LDA",
@@ -55,6 +58,7 @@ const INSTRUCTIONS: &[Instruction] = &[
             let value = m.fetch().unwrap();
             m.reg_set("AC", value);
         },
+        cycles: 2,
     },
     Instruction {
         mnemonic: "INY",
@@ -64,6 +68,7 @@ const INSTRUCTIONS: &[Instruction] = &[
             let reg = m.reg_mut("YR");
             *reg = reg.wrapping_add(1);
         },
+        cycles: 2,
     },
     Instruction {
         mnemonic: "INX",
@@ -73,6 +78,7 @@ const INSTRUCTIONS: &[Instruction] = &[
             let reg = m.reg_mut("XR");
             *reg = reg.wrapping_add(1);
         },
+        cycles: 2,
     },
 ];
 

--- a/crates/rmachine-mos6502/src/lib.rs
+++ b/crates/rmachine-mos6502/src/lib.rs
@@ -2,93 +2,113 @@ use std::ops::{Deref, DerefMut};
 
 use rmachine_core::prelude::*;
 
-const REGISTERS: &[&str] = &["SR", "AC", "XR", "YR", "SP"];
-
 const CARRY: u8 = 0b0000_0001;
 const DECIMAL: u8 = 0b0000_1000;
-
-const INSTRUCTIONS: &[Instruction] = &[
-    Instruction {
-        mnemonic: "CLC",
-        opcode: 0x18,
-        operands: Operands::Zero,
-        execute: |m| {
-            let status = m.reg_mut("SR");
-            *status &= !CARRY;
-        },
-        cycles: 2,
-    },
-    Instruction {
-        mnemonic: "CLD",
-        opcode: 0xD8,
-        operands: Operands::Zero,
-        execute: |m| {
-            let status = m.reg_mut("SR");
-            *status &= !DECIMAL;
-        },
-        cycles: 2,
-    },
-    Instruction {
-        mnemonic: "ADC",
-        opcode: 0x69,
-        operands: Operands::One,
-        execute: |m| {
-            let carry = m.reg("SR") & CARRY;
-            let operand = m.fetch().unwrap();
-            let reg = m.reg_mut("AC");
-
-            let (result, overflow) = reg.overflowing_add(operand);
-            let (result, overflow2) = result.overflowing_add(carry);
-            *reg = result;
-
-            let status = m.reg_mut("SR");
-            if overflow || overflow2 {
-                *status |= CARRY;
-            } else {
-                *status &= !CARRY;
-            }
-        },
-        cycles: 2,
-    },
-    Instruction {
-        mnemonic: "LDA",
-        opcode: 0xA9,
-        operands: Operands::One,
-        execute: |m| {
-            let value = m.fetch().unwrap();
-            m.reg_set("AC", value);
-        },
-        cycles: 2,
-    },
-    Instruction {
-        mnemonic: "INY",
-        opcode: 0xC8,
-        operands: Operands::Zero,
-        execute: |m| {
-            let reg = m.reg_mut("YR");
-            *reg = reg.wrapping_add(1);
-        },
-        cycles: 2,
-    },
-    Instruction {
-        mnemonic: "INX",
-        opcode: 0xE8,
-        operands: Operands::Zero,
-        execute: |m| {
-            let reg = m.reg_mut("XR");
-            *reg = reg.wrapping_add(1);
-        },
-        cycles: 2,
-    },
-];
 
 #[derive(Debug)]
 pub struct MOS6502(Machine);
 
 impl MOS6502 {
+    /// Constructs a new 6502.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any duplicate opcodes are defined.
     #[must_use]
     pub fn new() -> Self {
-        Self::default()
+        MOS6502::default()
+    }
+}
+
+impl Default for MOS6502 {
+    /// Constructs a new 6502.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any duplicate opcodes are defined.
+    fn default() -> Self {
+        Self(
+            MachineBuilder {
+                memory_size: 1024,
+                registers: &["SR", "AC", "XR", "YR", "SP"],
+                instructions: &[
+                    Instruction {
+                        mnemonic: "CLC",
+                        opcode: 0x18,
+                        operands: Operands::Zero,
+                        execute: |m| {
+                            let status = m.reg_mut("SR");
+                            *status &= !CARRY;
+                        },
+                        cycles: 2,
+                    },
+                    Instruction {
+                        mnemonic: "CLD",
+                        opcode: 0xD8,
+                        operands: Operands::Zero,
+                        execute: |m| {
+                            let status = m.reg_mut("SR");
+                            *status &= !DECIMAL;
+                        },
+                        cycles: 2,
+                    },
+                    Instruction {
+                        mnemonic: "ADC",
+                        opcode: 0x69,
+                        operands: Operands::One,
+                        execute: |m| {
+                            let carry = m.reg("SR") & CARRY;
+                            let operand = m.fetch().unwrap();
+                            let reg = m.reg_mut("AC");
+
+                            let (result, overflow) = reg.overflowing_add(operand);
+                            let (result, overflow2) = result.overflowing_add(carry);
+                            *reg = result;
+
+                            let status = m.reg_mut("SR");
+                            if overflow || overflow2 {
+                                *status |= CARRY;
+                            } else {
+                                *status &= !CARRY;
+                            }
+                        },
+                        cycles: 2,
+                    },
+                    Instruction {
+                        mnemonic: "LDA",
+                        opcode: 0xA9,
+                        operands: Operands::One,
+                        execute: |m| {
+                            let value = m.fetch().unwrap();
+                            m.reg_set("AC", value);
+                        },
+                        cycles: 2,
+                    },
+                    Instruction {
+                        mnemonic: "INY",
+                        opcode: 0xC8,
+                        operands: Operands::Zero,
+                        execute: |m| {
+                            let reg = m.reg_mut("YR");
+                            *reg = reg.wrapping_add(1);
+                        },
+                        cycles: 2,
+                    },
+                    Instruction {
+                        mnemonic: "INX",
+                        opcode: 0xE8,
+                        operands: Operands::Zero,
+                        execute: |m| {
+                            let reg = m.reg_mut("XR");
+                            *reg = reg.wrapping_add(1);
+                        },
+                        cycles: 2,
+                    },
+                ],
+                frequency_mhz: 1.0,
+            }
+            .build(),
+        )
     }
 }
 
@@ -103,17 +123,6 @@ impl Deref for MOS6502 {
 impl DerefMut for MOS6502 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
-    }
-}
-
-impl Default for MOS6502 {
-    fn default() -> Self {
-        let machine = MachineBuilder::default()
-            .with_memory(1024)
-            .with_registers(REGISTERS)
-            .with_instructions(INSTRUCTIONS)
-            .build();
-        Self(machine)
     }
 }
 

--- a/crates/rmachine-mos6502/src/lib.rs
+++ b/crates/rmachine-mos6502/src/lib.rs
@@ -2,8 +2,8 @@ use std::ops::{Deref, DerefMut};
 
 use rmachine_core::prelude::*;
 
-const CARRY: u8 = 0b0000_0001;
-const DECIMAL: u8 = 0b0000_1000;
+mod flags;
+mod instructions;
 
 #[derive(Debug)]
 pub struct MOS6502(Machine);
@@ -27,85 +27,13 @@ impl Default for MOS6502 {
     ///
     /// Panics if any duplicate opcodes are defined.
     fn default() -> Self {
+        use instructions::INSTRUCTIONS;
         Self(
             MachineBuilder {
                 memory_size: 1024,
                 registers: &["SR", "AC", "XR", "YR", "SP"],
-                instructions: &[
-                    Instruction {
-                        mnemonic: "CLC",
-                        opcode: 0x18,
-                        operands: Operands::Zero,
-                        execute: |m| {
-                            let status = m.reg_mut("SR");
-                            *status &= !CARRY;
-                        },
-                        cycles: 2,
-                    },
-                    Instruction {
-                        mnemonic: "CLD",
-                        opcode: 0xD8,
-                        operands: Operands::Zero,
-                        execute: |m| {
-                            let status = m.reg_mut("SR");
-                            *status &= !DECIMAL;
-                        },
-                        cycles: 2,
-                    },
-                    Instruction {
-                        mnemonic: "ADC",
-                        opcode: 0x69,
-                        operands: Operands::One,
-                        execute: |m| {
-                            let carry = m.reg("SR") & CARRY;
-                            let operand = m.fetch().unwrap();
-                            let reg = m.reg_mut("AC");
-
-                            let (result, overflow) = reg.overflowing_add(operand);
-                            let (result, overflow2) = result.overflowing_add(carry);
-                            *reg = result;
-
-                            let status = m.reg_mut("SR");
-                            if overflow || overflow2 {
-                                *status |= CARRY;
-                            } else {
-                                *status &= !CARRY;
-                            }
-                        },
-                        cycles: 2,
-                    },
-                    Instruction {
-                        mnemonic: "LDA",
-                        opcode: 0xA9,
-                        operands: Operands::One,
-                        execute: |m| {
-                            let value = m.fetch().unwrap();
-                            m.reg_set("AC", value);
-                        },
-                        cycles: 2,
-                    },
-                    Instruction {
-                        mnemonic: "INY",
-                        opcode: 0xC8,
-                        operands: Operands::Zero,
-                        execute: |m| {
-                            let reg = m.reg_mut("YR");
-                            *reg = reg.wrapping_add(1);
-                        },
-                        cycles: 2,
-                    },
-                    Instruction {
-                        mnemonic: "INX",
-                        opcode: 0xE8,
-                        operands: Operands::Zero,
-                        execute: |m| {
-                            let reg = m.reg_mut("XR");
-                            *reg = reg.wrapping_add(1);
-                        },
-                        cycles: 2,
-                    },
-                ],
-                frequency_mhz: 1.0,
+                instructions: INSTRUCTIONS,
+                frequency_mhz: 2.0,
             }
             .build(),
         )
@@ -128,6 +56,8 @@ impl DerefMut for MOS6502 {
 
 #[cfg(test)]
 mod tests {
+    use crate::flags::{CARRY, DECIMAL};
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
This PR adds a time delay after each instruction to reflect:

1. The actual number of clock cycles consumed by the specific instruction, and
2. The clock speed of the emulated CPU.

In other words, rather than simply executing instructions as fast as the host computer will allow, the emulator will now run at (very close to) the desired clock speed (for example 2MHz). Emulator overhead is not accounted for (we assume the host computer is very fast compared to the emulated system).