### PR TITLE
Add LDX, LDY, BNE and new addressing modes

### DIFF
--- a/crates/rmachine-core/src/machine.rs
+++ b/crates/rmachine-core/src/machine.rs
@@ -21,6 +21,7 @@ use crate::exception::Exception;
 pub enum Mode {
     Implied,
     Immediate,
+    ZeroPage,
     Absolute,
 }
 

--- a/crates/rmachine-core/src/machine.rs
+++ b/crates/rmachine-core/src/machine.rs
@@ -23,6 +23,7 @@ pub enum Mode {
     Immediate,
     ZeroPage,
     Absolute,
+    Relative,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rmachine-mos6502/src/flags.rs
+++ b/crates/rmachine-mos6502/src/flags.rs
@@ -1,2 +1,7 @@
+/// Flags used in the status register.
+///
+/// 7 6 5 4 3 2 1 0
+/// N V - B D I Z C
 pub const CARRY: u8 = 0b0000_0001;
+pub const ZERO: u8 = 0b0000_0010;
 pub const DECIMAL: u8 = 0b0000_1000;

--- a/crates/rmachine-mos6502/src/instructions.rs
+++ b/crates/rmachine-mos6502/src/instructions.rs
@@ -105,9 +105,9 @@ pub const INSTRUCTIONS: &[Instruction] = &[
         cycles: 2,
         execute: |m| {
             let offset = m.fetch8();
-            let signed_offset = offset.cast_signed();
+            let signed_offset = i16::from(offset.cast_signed());
             if !m.test_bit("SR", ZERO) {
-                m.pc = m.pc.wrapping_add_signed(i16::from(signed_offset));
+                m.pc = m.pc.wrapping_add_signed(signed_offset);
             }
         },
         test: |m| {

--- a/crates/rmachine-mos6502/src/instructions.rs
+++ b/crates/rmachine-mos6502/src/instructions.rs
@@ -1,6 +1,6 @@
 use rmachine_core::{exception::Exception, machine::Mode, prelude::*};
 
-use crate::flags::{CARRY, DECIMAL};
+use crate::flags::{CARRY, DECIMAL, ZERO};
 
 /// Performs ADC (Add with Carry) operation.
 ///
@@ -95,6 +95,46 @@ pub const INSTRUCTIONS: &[Instruction] = &[
                 0x00, // 0x0000 BRK
             ]);
             assert_eq!(m.pc, 0x0001, "wrong PC");
+        },
+    },
+    Instruction {
+        mnemonic: "BNE",
+        mode: Mode::Relative,
+        opcode: 0xD0,
+        bytes: 2,
+        cycles: 2,
+        execute: |m| {
+            let offset = m.fetch8();
+            let signed_offset = offset.cast_signed();
+            if !m.test_bit("SR", ZERO) {
+                m.pc = m.pc.wrapping_add_signed(i16::from(signed_offset));
+            }
+        },
+        test: |m| {
+            // Test branch forward
+            m.clear_bit("SR", ZERO);
+            m.set_bit("SR", CARRY);
+            m.run_program(&[
+                0xD0, 0x01, // 0x0000 BNE $01
+                0x00, //       0x0002 BRK (skipped)
+                0x18, //       0x0003 CLC
+                0x00, //       0x0004 BRK
+            ]);
+            assert_eq!(m.pc(), 0x0005, "wrong PC");
+            assert!(!m.test_bit("SR", CARRY), "carry not cleared");
+
+            // Test branch backward
+            m.clear_bit("SR", ZERO);
+            m.set_bit("SR", CARRY);
+            m.run_program(&[
+                0x4C, 0x05, 0x00, // $0000 JMP $0005
+                0x18, //             $0003 CLC
+                0x00, //             $0004 BRK
+                0xD0, 0xFC, //       $0005 BNE $FC (branch to $0003, -4 back from pc := $0007)
+                0x00, //             $0007 BRK (skipped)
+            ]);
+            assert_eq!(m.pc(), 0x0005, "wrong PC");
+            assert!(!m.test_bit("SR", CARRY), "carry not cleared");
         },
     },
     Instruction {

--- a/crates/rmachine-mos6502/src/instructions.rs
+++ b/crates/rmachine-mos6502/src/instructions.rs
@@ -193,8 +193,28 @@ pub const INSTRUCTIONS: &[Instruction] = &[
         },
         test: |m| {
             m.run_program(&[
-                0xA9, 0xFF, // 0x0000 LDA #FF
+                0xA9, 0xFF, // 0x0000 LDA #$FF
                 0x00, //       0x0002 BRK
+            ]);
+            assert_eq!(m.reg("AC"), 0xFF, "wrong AC");
+        },
+    },
+    Instruction {
+        mnemonic: "LDA",
+        mode: Mode::ZeroPage,
+        opcode: 0xA5,
+        bytes: 2,
+        cycles: 3,
+        execute: |m| {
+            let addr = m.fetch8();
+            let op = m.get8(u16::from(addr));
+            m.set_reg("AC", op);
+        },
+        test: |m| {
+            m.run_program(&[
+                0xA5, 0x03, // 0x0000 LDA $03
+                0x00, //       0x0002 BRK
+                0xFF, //       0x0003 DB #$FF
             ]);
             assert_eq!(m.reg("AC"), 0xFF, "wrong AC");
         },
@@ -214,9 +234,125 @@ pub const INSTRUCTIONS: &[Instruction] = &[
             m.run_program(&[
                 0xAD, 0x04, 0x00, // 0x0000 LDA $0004
                 0x00, //             0x0003 BRK
-                0xFF, //             0x0004 DB #FF
+                0xFF, //             0x0004 DB #$FF
             ]);
             assert_eq!(m.reg("AC"), 0xFF, "wrong AC");
+        },
+    },
+    Instruction {
+        mnemonic: "LDX",
+        mode: Mode::Immediate,
+        opcode: 0xA2,
+        bytes: 2,
+        cycles: 2,
+        execute: |m| {
+            let op = m.fetch8();
+            m.set_reg("XR", op);
+        },
+        test: |m| {
+            m.run_program(&[
+                0xA2, 0x2a, // 0x0000 LDX #$2a
+                0x00, //       0x0002 BRK
+            ]);
+            assert_eq!(m.reg("XR"), 0x2a, "wrong XR");
+        },
+    },
+    Instruction {
+        mnemonic: "LDX",
+        mode: Mode::ZeroPage,
+        opcode: 0xA6,
+        bytes: 2,
+        cycles: 3,
+        execute: |m| {
+            let addr = m.fetch8();
+            let op = m.get8(u16::from(addr));
+            m.set_reg("XR", op);
+        },
+        test: |m| {
+            m.run_program(&[
+                0xA6, 0x03, // 0x0000 LDX $03
+                0x00, //       0x0002 BRK
+                0x2a, //       0x0003 DB #$2a
+            ]);
+            assert_eq!(m.reg("XR"), 0x2a, "wrong XR");
+        },
+    },
+    Instruction {
+        mnemonic: "LDX",
+        mode: Mode::Absolute,
+        opcode: 0xAE,
+        bytes: 3,
+        cycles: 4,
+        execute: |m| {
+            let addr = m.fetch16();
+            let op = m.get8(addr);
+            m.set_reg("XR", op);
+        },
+        test: |m| {
+            m.run_program(&[
+                0xAE, 0x04, 0x00, // 0x0000 LDX $0004
+                0x00, //             0x0003 BRK
+                0x2a, //             0x0004 DB #$2a
+            ]);
+            assert_eq!(m.reg("XR"), 0x2a, "wrong XR");
+        },
+    },
+    Instruction {
+        mnemonic: "LDY",
+        mode: Mode::Immediate,
+        opcode: 0xA0,
+        bytes: 2,
+        cycles: 2,
+        execute: |m| {
+            let op = m.fetch8();
+            m.set_reg("YR", op);
+        },
+        test: |m| {
+            m.run_program(&[
+                0xA0, 0x2a, // 0x0000 LDY #$2a
+                0x00, //       0x0002 BRK
+            ]);
+            assert_eq!(m.reg("YR"), 0x2a, "wrong YR");
+        },
+    },
+    Instruction {
+        mnemonic: "LDY",
+        mode: Mode::ZeroPage,
+        opcode: 0xA4,
+        bytes: 2,
+        cycles: 3,
+        execute: |m| {
+            let addr = m.fetch8();
+            let op = m.get8(u16::from(addr));
+            m.set_reg("YR", op);
+        },
+        test: |m| {
+            m.run_program(&[
+                0xA4, 0x03, // 0x0000 LDY $03
+                0x00, //       0x0002 BRK
+                0x2a, //       0x0003 DB #$2a
+            ]);
+            assert_eq!(m.reg("YR"), 0x2a, "wrong YR");
+        },
+    },
+    Instruction {
+        mnemonic: "LDY",
+        mode: Mode::Absolute,
+        opcode: 0xAC,
+        bytes: 3,
+        cycles: 4,
+        execute: |m| {
+            let addr = m.fetch16();
+            let op = m.get8(addr);
+            m.set_reg("YR", op);
+        },
+        test: |m| {
+            m.run_program(&[
+                0xAC, 0x04, 0x00, // 0x0000 LDY $0004
+                0x00, //             0x0003 BRK
+                0x2a, //             0x0004 DB #$2a
+            ]);
+            assert_eq!(m.reg("YR"), 0x2a, "wrong YR");
         },
     },
     Instruction {


### PR DESCRIPTION
## Summary
- Add ZeroPage and Relative addressing modes
- Implement LDX and LDY (immediate, zero page, absolute)
- Add LDA zero page mode
- Implement BNE (relative)

## Test plan
- [x] Each instruction includes self-tests