### PR TITLE
Add 6502 interrupt/reset vectoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /testdata/hello*
 !/testdata/**/*.s
 .claude
+.zed

--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -1,0 +1,5 @@
+// Project-local debug tasks
+//
+// For more documentation on how to configure debug tasks,
+// see: https://zed.dev/docs/debugger
+[]

--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -1,5 +1,0 @@
-// Project-local debug tasks
-//
-// For more documentation on how to configure debug tasks,
-// see: https://zed.dev/docs/debugger
-[]

--- a/crates/rmachine-core/src/machine.rs
+++ b/crates/rmachine-core/src/machine.rs
@@ -260,10 +260,8 @@ impl Machine {
     /// No alignment requirements apply.
     pub fn set16(&mut self, addr: u16, value: u16) {
         let [lo, hi] = value.to_le_bytes();
-        let addr = usize::from(addr);
-        if let Some(mem) = self.memory.get_mut(addr..=addr.wrapping_add(1)) {
-            (mem[0], mem[1]) = (lo, hi);
-        }
+        self.set8(addr, lo);
+        self.set8(addr.wrapping_add(1), hi);
     }
 
     /// Load bytes into memory at the given address.
@@ -543,12 +541,27 @@ mod tests {
     }
 
     #[test]
-    fn get16_returns_a_16_bit_value_from_memory() {
+    fn get16_returns_le_word_from_memory() {
         let mut machine = new_tiny_machine();
 
         machine.load(0, &[0xEF, 0xBE]).unwrap();
 
         assert_eq!(machine.get16(0), 0xBEEF);
+    }
+
+    #[test]
+    fn get16_returns_le_word_from_memory_at_wrapping_addr() {
+        let mut m = MachineBuilder {
+            memory_size: 0x10_000, // 64KiB
+            registers: &["AC", "XR", "YR"],
+            instructions: INSTRUCTIONS,
+            frequency_hz: 1_000_000,
+            ..Default::default()
+        }
+        .build();
+        m.set8(0xFFFF, 0xEF);
+        m.set8(0x0000, 0xBE);
+        assert_eq!(m.get16(0xFFFF), 0xBEEF, "wrong value");
     }
 
     #[test]
@@ -575,7 +588,23 @@ mod tests {
     fn set16_writes_le_word_to_memory() {
         let mut machine = new_tiny_machine();
         machine.set16(0, 0xBEEF);
-        assert_eq!(machine.get16(0), 0xBEEF, "wrong memory contents");
+        assert_eq!(machine.get8(0), 0xEF, "wrong low byte");
+        assert_eq!(machine.get8(1), 0xBE, "wrong high byte");
+    }
+
+    #[test]
+    fn set16_writes_le_word_to_memory_at_wrapping_addr() {
+        let mut m = MachineBuilder {
+            memory_size: 0x10_000, // 64KiB
+            registers: &["AC", "XR", "YR"],
+            instructions: INSTRUCTIONS,
+            frequency_hz: 1_000_000,
+            ..Default::default()
+        }
+        .build();
+        m.set16(0xFFFF, 0xBEEF);
+        assert_eq!(m.get8(0xFFFF), 0xEF, "wrong low byte");
+        assert_eq!(m.get8(0x0000), 0xBE, "wrong high byte");
     }
 
     #[test]

--- a/crates/rmachine-core/src/machine.rs
+++ b/crates/rmachine-core/src/machine.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::cast_possible_truncation)]
 use std::collections::HashMap;
-use std::fmt::Display;
-use std::fmt::Write;
+use std::fmt::{Display, Write};
 use std::fs;
 use std::ops::Div;
 use std::panic;
@@ -39,24 +38,28 @@ pub struct Instruction {
     pub test: fn(&mut Machine),
 }
 
-#[derive(Debug)]
+pub type HandlerMap = HashMap<&'static str, fn(&mut Machine)>;
+
+#[derive(Debug, Default)]
 pub struct Machine {
     memory: Vec<u8>,
     pub pc: u16,
     pub registers: HashMap<&'static str, u8>,
     register_list: &'static [&'static str],
     instructions: HashMap<u8, &'static Instruction>,
+    handlers: HandlerMap,
     cycles: u64,
     cycle_time_ns: u64,
     timer_ns: u64,
     pub exception: Option<Exception>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MachineBuilder {
     pub memory_size: usize,
     pub registers: &'static [&'static str],
     pub instructions: &'static [Instruction],
+    pub handlers: HandlerMap,
     pub frequency_hz: u64,
 }
 
@@ -90,13 +93,11 @@ impl MachineBuilder {
                 }
                 instructions
             },
+            handlers: self.handlers,
             cycle_time_ns: 1_000_000_000_u64
                 .checked_div(self.frequency_hz)
                 .expect("frequency must be non-zero"),
-            pc: 0,
-            cycles: 0,
-            timer_ns: 0,
-            exception: None,
+            ..Default::default()
         }
     }
 }
@@ -254,6 +255,17 @@ impl Machine {
         }
     }
 
+    /// Writes a (little-endian) word to memory at the given address.
+    ///
+    /// No alignment requirements apply.
+    pub fn set16(&mut self, addr: u16, value: u16) {
+        let [lo, hi] = value.to_le_bytes();
+        let addr = usize::from(addr);
+        if let Some(mem) = self.memory.get_mut(addr..=addr.wrapping_add(1)) {
+            (mem[0], mem[1]) = (lo, hi);
+        }
+    }
+
     /// Load bytes into memory at the given address.
     ///
     /// # Errors
@@ -390,6 +402,12 @@ impl Machine {
         Some(disassembly)
     }
 
+    pub fn signal(&mut self, signal: &'static str) {
+        if let Some(handler) = self.handlers.get(signal) {
+            (handler)(self);
+        }
+    }
+
     pub fn trap(&mut self, x: Exception) {
         self.exception = Some(x);
     }
@@ -494,6 +512,7 @@ mod tests {
             registers: &["AC", "XR", "YR"],
             instructions: INSTRUCTIONS,
             frequency_hz: 1_000_000,
+            ..Default::default()
         }
         .build()
     }
@@ -550,6 +569,13 @@ mod tests {
 
         // Should not panic, and reading out of bounds returns 0
         assert_eq!(machine.get8(2000), 0x00);
+    }
+
+    #[test]
+    fn set16_writes_le_word_to_memory() {
+        let mut machine = new_tiny_machine();
+        machine.set16(0, 0xBEEF);
+        assert_eq!(machine.get16(0), 0xBEEF, "wrong memory contents");
     }
 
     #[test]

--- a/crates/rmachine-mos6502/src/constants.rs
+++ b/crates/rmachine-mos6502/src/constants.rs
@@ -1,0 +1,8 @@
+pub const NMI: &str = "NMI";
+pub const NMI_VECTOR: u16 = 0xFFFA;
+
+pub const RESET: &str = "RESET";
+pub const RESET_VECTOR: u16 = 0xFFFC;
+
+pub const IRQ: &str = "IRQ";
+pub const IRQ_VECTOR: u16 = 0xFFFE;

--- a/crates/rmachine-mos6502/src/handlers.rs
+++ b/crates/rmachine-mos6502/src/handlers.rs
@@ -1,0 +1,22 @@
+use std::{collections::HashMap, sync::LazyLock};
+
+use rmachine_core::machine::HandlerMap;
+
+use crate::{IRQ, IRQ_VECTOR, NMI, NMI_VECTOR, RESET, RESET_VECTOR};
+
+pub static HANDLERS: LazyLock<HandlerMap> = LazyLock::new(|| {
+    let mut handlers: HandlerMap = HashMap::new();
+    handlers.insert(RESET, |m| {
+        m.pc = m.get16(RESET_VECTOR);
+        m.step();
+    });
+    handlers.insert(IRQ, |m| {
+        m.pc = m.get16(IRQ_VECTOR);
+        m.step();
+    });
+    handlers.insert(NMI, |m| {
+        m.pc = m.get16(NMI_VECTOR);
+        m.step();
+    });
+    handlers
+});

--- a/crates/rmachine-mos6502/src/lib.rs
+++ b/crates/rmachine-mos6502/src/lib.rs
@@ -2,8 +2,12 @@ use std::ops::{Deref, DerefMut};
 
 use rmachine_core::prelude::*;
 
+mod constants;
 mod flags;
+mod handlers;
 mod instructions;
+
+pub use constants::*;
 
 #[derive(Debug)]
 pub struct MOS6502(Machine);
@@ -27,12 +31,14 @@ impl Default for MOS6502 {
     ///
     /// Panics if any duplicate opcodes are defined.
     fn default() -> Self {
+        use handlers::HANDLERS;
         use instructions::INSTRUCTIONS;
         Self(
             MachineBuilder {
                 memory_size: 0x10_000, // 64KiB
                 registers: &["SR", "AC", "XR", "YR", "SP"],
                 instructions: INSTRUCTIONS,
+                handlers: (*HANDLERS).clone(),
                 frequency_hz: 2_000_000,
             }
             .build(),
@@ -61,5 +67,29 @@ mod tests {
     #[test]
     fn machine_self_tests_pass() {
         MOS6502::new().self_test();
+    }
+
+    #[test]
+    fn machine_jumps_to_reset_vector_on_reset() {
+        let mut m = MOS6502::new();
+        m.set16(RESET_VECTOR, 0x1000);
+        m.signal(RESET);
+        assert_eq!(m.pc, 0x1001, "PC {:#06X} != 0x1001", m.pc);
+    }
+
+    #[test]
+    fn machine_jumps_to_irq_vector_on_irq() {
+        let mut m = MOS6502::new();
+        m.set16(IRQ_VECTOR, 0x1000);
+        m.signal(IRQ);
+        assert_eq!(m.pc, 0x1001, "PC {:#06X} != 0x1001", m.pc);
+    }
+
+    #[test]
+    fn machine_jumps_to_nmi_vector_on_nmi() {
+        let mut m = MOS6502::new();
+        m.set16(NMI_VECTOR, 0x1000);
+        m.signal(NMI);
+        assert_eq!(m.pc, 0x1001, "PC {:#06X} != 0x1001", m.pc);
     }
 }


### PR DESCRIPTION
This adds a 'signal' mechanism to the core `Machine` so that CPUs can support arbitrary signal pins. Also adds simple signal handlers to the 6502 implementation for the NMI, IRQ, and RESET pins that jump to the hard-wired interrupt vectors at $FFFA/FB (NMI), $FFC/FD (RESET), and $FFFE/FF (IRQ/BRK). This implementation does not push PC and SP, or set the B flag on BRK (this is TODO).

See https://www.pagetable.com/?p=410 for more details about the real silicon.

